### PR TITLE
apple: Fix zip command to preserve symlinks

### DIFF
--- a/apple/build-xcframework.sh
+++ b/apple/build-xcframework.sh
@@ -26,7 +26,7 @@ rm -rf ./connlib-macosx.xcarchive
 
 echo "Computing checksum"
 touch Package.swift
-zip -r Connlib.xcframework.zip Connlib.xcframework
+zip -r -y Connlib.xcframework.zip Connlib.xcframework
 swift package compute-checksum Connlib.xcframework.zip > Connlib.xcframework.zip.checksum.txt
 
 rm Package.swift


### PR DESCRIPTION
Need to preserve symlinks so that the framework works correctly when used from macOS (which requires Versions/Current as a symlink to Versions/A).

Ref: https://developer.apple.com/documentation/bundleresources/placing_content_in_a_bundle#3875936

Without the symlink, Xcode's code signing doesn't work correctly when building the macOS app that uses connlib, so there are errors when building with Xcode:

~~~
/Users/roop/Library/Developer/Xcode/DerivedData/Firezone-dcqkramxuiulsxhcbuklbcfgaury/Build/Products/Debug/Firezone.app: code object is not signed at all
In subcomponent: /Users/roop/Library/Developer/Xcode/DerivedData/Firezone-dcqkramxuiulsxhcbuklbcfgaury/Build/Products/Debug/Firezone.app/Contents/Frameworks/connlib.framework
~~~

