### PR TITLE
[WIP] Apple: Adopt FFI changes and update the API exposed to Apple clients

### DIFF
--- a/apple/Sources/Connlib/Adapter.swift
+++ b/apple/Sources/Connlib/Adapter.swift
@@ -77,7 +77,7 @@ public class Adapter {
   /// Start the tunnel tunnel.
   /// - Parameters:
   ///   - completionHandler: completion handler.
-  public func start(completionHandler: @escaping (AdapterError?) -> Void) throws {
+  public func start(portalURL: String, token: String, completionHandler: @escaping (AdapterError?) -> Void) throws {
     workQueue.async {
       guard case .stopped = self.state else {
         completionHandler(.invalidState)
@@ -95,8 +95,8 @@ public class Adapter {
 
         self.state = .started(
           WrappedSession.connect(
-            "http://localhost:4568",
-            "test-token",
+            portalURL,
+            token,
             Self.callbackHandler!
           )
         )

--- a/apple/Sources/Connlib/CallbackHandler.swift
+++ b/apple/Sources/Connlib/CallbackHandler.swift
@@ -77,3 +77,17 @@ public class CallbackHandler {
         }
     }
 }
+
+extension ResourceList {
+    enum ParseError: Error {
+        case notUTF8
+    }
+
+    func toResources() throws -> [Resource] {
+        let jsonString = resources.toString()
+        guard let jsonData = jsonString.data(using: .utf8) else {
+            throw ParseError.notUTF8
+        }
+        return try JSONDecoder().decode([Resource].self, from: jsonData)
+    }
+}

--- a/apple/Sources/Connlib/CallbackHandler.swift
+++ b/apple/Sources/Connlib/CallbackHandler.swift
@@ -9,11 +9,11 @@ import NetworkExtension
 import os.log
 
 public protocol CallbackHandlerDelegate: AnyObject {
-    func didUpdateResources(_ resourceList: ResourceList)
+    func didUpdateResources(_ resources: [Resource])
+    func didUpdateInterfaceAddresses(_ interfaceAddresses: InterfaceAddresses)
 }
 
 public class CallbackHandler {
-    // TODO: Add a table view property here to update?
     var adapter: Adapter
     public weak var delegate: CallbackHandlerDelegate?
 
@@ -23,58 +23,28 @@ public class CallbackHandler {
 
     func onUpdateResources(resourceList: ResourceList) -> Bool {
 
-        // If there's any entity that assigned itself as this callbackHandler's delegate, it will be called everytime this `onUpdateResources` method is, allowing that entity to react to resource updates and do whatever they want.
+        let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
 
-        delegate?.didUpdateResources(resourceList)
+        do {
+            let resources = try resourceList.toResources()
+            logger.debug("Resources updated: \(resources)")
+            delegate?.didUpdateResources(resources)
+        } catch {
+            logger.error("Error parsing resource list: \(String(describing: error)) (JSON: \(resourceList.resources.toString()))")
+            return false
+        }
 
-        let addresses4 = self.adapter.lastNetworkSettings?.ipv4Settings?.addresses ?? ["100.100.111.2"]
-        let addresses6 = self.adapter.lastNetworkSettings?.ipv6Settings?.addresses ?? ["fd00:0222:2021:1111::2"]
-
-        // TODO: Use actual passed in resources to achieve split tunnel
-        let ipv4Routes = [NEIPv4Route(destinationAddress: "100.64.0.0", subnetMask: "255.192.0.0")]
-        let ipv6Routes = [
-            NEIPv6Route(destinationAddress: "fd00:0222:2021:1111::0", networkPrefixLength: 64)
-        ]
-
-        return setTunnelSettingsKeepingSomeExisting(
-            addresses4: addresses4, addresses6: addresses6, ipv4Routes: ipv4Routes, ipv6Routes: ipv6Routes
-        )
+        return true
     }
 
     func onSetTunnelAddresses(tunnelAddresses: TunnelAddresses) -> Bool {
-        let addresses4 = [tunnelAddresses.address4.toString()]
-        let addresses6 = [tunnelAddresses.address6.toString()]
-        let ipv4Routes = self.adapter.lastNetworkSettings?.ipv4Settings?.includedRoutes ?? []
-        let ipv6Routes = self.adapter.lastNetworkSettings?.ipv6Settings?.includedRoutes ?? []
-
-        return setTunnelSettingsKeepingSomeExisting(
-            addresses4: addresses4, addresses6: addresses6, ipv4Routes: ipv4Routes, ipv6Routes: ipv6Routes
-        )
-    }
-
-    private func setTunnelSettingsKeepingSomeExisting(
-        addresses4: [String], addresses6: [String],
-        ipv4Routes: [NEIPv4Route], ipv6Routes: [NEIPv6Route]) -> Bool {
-
         let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
-        do {
-            /* If the tunnel interface addresses are being updated, it's impossible for the tunnel to
-             stay up due to the way WireGuard works. Still, we try not to change the tunnel's routes
-             here Just In Case™.
-             */
-            try self.adapter.setNetworkSettings(
-                self.adapter.generateNetworkSettings(
-                    addresses4: addresses4,
-                    addresses6: addresses6,
-                    ipv4Routes: ipv4Routes,
-                    ipv6Routes: ipv6Routes
-                )
-            )
-            return true
-        } catch let error {
-            logger.log(level: .debug, "Error setting adapter settings: \(String(describing: error))")
-            return false
-        }
+
+        let interfaceAddresses = tunnelAddresses.toInterfaceAddresses()
+        logger.debug("Interface addresses updated: (\(interfaceAddresses.ipv4), \(interfaceAddresses.ipv6))")
+        delegate?.didUpdateInterfaceAddresses(interfaceAddresses)
+
+        return true
     }
 }
 

--- a/apple/Sources/Connlib/CallbackHandler.swift
+++ b/apple/Sources/Connlib/CallbackHandler.swift
@@ -14,7 +14,7 @@ public protocol CallbackHandlerDelegate: AnyObject {
 
 public class CallbackHandler {
     // TODO: Add a table view property here to update?
-    var adapter: Adapter?
+    var adapter: Adapter
     public weak var delegate: CallbackHandlerDelegate?
 
     init(adapter: Adapter) {
@@ -27,12 +27,8 @@ public class CallbackHandler {
 
         delegate?.didUpdateResources(resourceList)
 
-        let addresses4 =
-        self.adapter?.lastNetworkSettings?.ipv4Settings?.addresses ?? ["100.100.111.2"]
-        let addresses6 =
-        self.adapter?.lastNetworkSettings?.ipv6Settings?.addresses ?? [
-            "fd00:0222:2021:1111::2"
-        ]
+        let addresses4 = self.adapter.lastNetworkSettings?.ipv4Settings?.addresses ?? ["100.100.111.2"]
+        let addresses6 = self.adapter.lastNetworkSettings?.ipv6Settings?.addresses ?? ["fd00:0222:2021:1111::2"]
 
         // TODO: Use actual passed in resources to achieve split tunnel
         let ipv4Routes = [NEIPv4Route(destinationAddress: "100.64.0.0", subnetMask: "255.192.0.0")]
@@ -48,10 +44,8 @@ public class CallbackHandler {
     func onSetTunnelAddresses(tunnelAddresses: TunnelAddresses) -> Bool {
         let addresses4 = [tunnelAddresses.address4.toString()]
         let addresses6 = [tunnelAddresses.address6.toString()]
-        let ipv4Routes =
-        Adapter.currentAdapter?.lastNetworkSettings?.ipv4Settings?.includedRoutes ?? []
-        let ipv6Routes =
-        Adapter.currentAdapter?.lastNetworkSettings?.ipv6Settings?.includedRoutes ?? []
+        let ipv4Routes = self.adapter.lastNetworkSettings?.ipv4Settings?.includedRoutes ?? []
+        let ipv6Routes = self.adapter.lastNetworkSettings?.ipv6Settings?.includedRoutes ?? []
 
         return setTunnelSettingsKeepingSomeExisting(
             addresses4: addresses4, addresses6: addresses6, ipv4Routes: ipv4Routes, ipv6Routes: ipv6Routes
@@ -59,34 +53,26 @@ public class CallbackHandler {
     }
 
     private func setTunnelSettingsKeepingSomeExisting(
-        addresses4: [String], addresses6: [String], ipv4Routes: [NEIPv4Route], ipv6Routes: [NEIPv6Route]
-    ) -> Bool {
+        addresses4: [String], addresses6: [String],
+        ipv4Routes: [NEIPv4Route], ipv6Routes: [NEIPv6Route]) -> Bool {
+
         let logger = Logger(subsystem: "dev.firezone.firezone", category: "packet-tunnel")
-
-        if self.adapter != nil {
-            do {
-                /* If the tunnel interface addresses are being updated, it's impossible for the tunnel to
-                 stay up due to the way WireGuard works. Still, we try not to change the tunnel's routes
-                 here Just In Case™.
-                 */
-                try self.adapter!.setNetworkSettings(
-                    self.adapter!.generateNetworkSettings(
-                        addresses4: addresses4,
-                        addresses6: addresses6,
-                        ipv4Routes: ipv4Routes,
-                        ipv6Routes: ipv6Routes
-                    )
+        do {
+            /* If the tunnel interface addresses are being updated, it's impossible for the tunnel to
+             stay up due to the way WireGuard works. Still, we try not to change the tunnel's routes
+             here Just In Case™.
+             */
+            try self.adapter.setNetworkSettings(
+                self.adapter.generateNetworkSettings(
+                    addresses4: addresses4,
+                    addresses6: addresses6,
+                    ipv4Routes: ipv4Routes,
+                    ipv6Routes: ipv6Routes
                 )
-
-                return true
-            } catch let error {
-                logger.log(level: .debug, "Error setting adapter settings: \(String(describing: error))")
-
-                return false
-            }
-        } else {
-            logger.log(level: .debug, "Adapter not initialized!")
-
+            )
+            return true
+        } catch let error {
+            logger.log(level: .debug, "Error setting adapter settings: \(String(describing: error))")
             return false
         }
     }

--- a/apple/Sources/Connlib/CallbackHandler.swift
+++ b/apple/Sources/Connlib/CallbackHandler.swift
@@ -91,3 +91,9 @@ extension ResourceList {
         return try JSONDecoder().decode([Resource].self, from: jsonData)
     }
 }
+
+extension TunnelAddresses {
+    func toInterfaceAddresses() -> InterfaceAddresses {
+        InterfaceAddresses(ipv4: address4.toString(), ipv6: address6.toString())
+    }
+}

--- a/apple/Sources/Connlib/Models/IPAddressRange.swift
+++ b/apple/Sources/Connlib/Models/IPAddressRange.swift
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2018-2023 WireGuard LLC. All Rights Reserved.
+
+import Foundation
+import Network
+
+public struct IPAddressRange {
+    public let address: IPAddress
+    public let networkPrefixLength: UInt8
+
+    init(address: IPAddress, networkPrefixLength: UInt8) {
+        self.address = address
+        self.networkPrefixLength = networkPrefixLength
+    }
+}
+
+extension IPAddressRange: Equatable {
+    public static func == (lhs: IPAddressRange, rhs: IPAddressRange) -> Bool {
+        return lhs.address.rawValue == rhs.address.rawValue && lhs.networkPrefixLength == rhs.networkPrefixLength
+    }
+}
+
+extension IPAddressRange: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(address.rawValue)
+        hasher.combine(networkPrefixLength)
+    }
+}
+
+extension IPAddressRange {
+    public var stringRepresentation: String {
+        return "\(address)/\(networkPrefixLength)"
+    }
+
+    public init?(from string: String) {
+        guard let parsed = IPAddressRange.parseAddressString(string) else { return nil }
+        address = parsed.0
+        networkPrefixLength = parsed.1
+    }
+
+    private static func parseAddressString(_ string: String) -> (IPAddress, UInt8)? {
+        let endOfIPAddress = string.lastIndex(of: "/") ?? string.endIndex
+        let addressString = String(string[string.startIndex ..< endOfIPAddress])
+        let address: IPAddress
+        if let addr = IPv4Address(addressString) {
+            address = addr
+        } else if let addr = IPv6Address(addressString) {
+            address = addr
+        } else {
+            return nil
+        }
+
+        let maxNetworkPrefixLength: UInt8 = address is IPv4Address ? 32 : 128
+        var networkPrefixLength: UInt8
+        if endOfIPAddress < string.endIndex { // "/" was located
+            let indexOfNetworkPrefixLength = string.index(after: endOfIPAddress)
+            guard indexOfNetworkPrefixLength < string.endIndex else { return nil }
+            let networkPrefixLengthSubstring = string[indexOfNetworkPrefixLength ..< string.endIndex]
+            guard let npl = UInt8(networkPrefixLengthSubstring) else { return nil }
+            networkPrefixLength = min(npl, maxNetworkPrefixLength)
+        } else {
+            networkPrefixLength = maxNetworkPrefixLength
+        }
+
+        return (address, networkPrefixLength)
+    }
+
+    public func subnetMask() -> IPAddress {
+        if address is IPv4Address {
+            let mask = networkPrefixLength > 0 ? ~UInt32(0) << (32 - networkPrefixLength) : UInt32(0)
+            let bytes = Data([
+                UInt8(truncatingIfNeeded: mask >> 24),
+                UInt8(truncatingIfNeeded: mask >> 16),
+                UInt8(truncatingIfNeeded: mask >> 8),
+                UInt8(truncatingIfNeeded: mask >> 0)
+            ])
+            return IPv4Address(bytes)!
+        }
+        if address is IPv6Address {
+            var bytes = Data(repeating: 0, count: 16)
+            for i in 0..<Int(networkPrefixLength/8) {
+                bytes[i] = 0xff
+            }
+            let nibble = networkPrefixLength % 32
+            if nibble != 0 {
+                let mask = ~UInt32(0) << (32 - nibble)
+                let i = Int(networkPrefixLength / 32 * 4)
+                bytes[i + 0] = UInt8(truncatingIfNeeded: mask >> 24)
+                bytes[i + 1] = UInt8(truncatingIfNeeded: mask >> 16)
+                bytes[i + 2] = UInt8(truncatingIfNeeded: mask >> 8)
+                bytes[i + 3] = UInt8(truncatingIfNeeded: mask >> 0)
+            }
+            return IPv6Address(bytes)!
+        }
+        fatalError()
+    }
+
+    public func maskedAddress() -> IPAddress {
+        let subnet = subnetMask().rawValue
+        var masked = Data(address.rawValue)
+        if subnet.count != masked.count {
+            fatalError()
+        }
+        for i in 0..<subnet.count {
+            masked[i] &= subnet[i]
+        }
+        if subnet.count == 4 {
+            return IPv4Address(masked)!
+        }
+        if subnet.count == 16 {
+            return IPv6Address(masked)!
+        }
+        fatalError()
+    }
+}

--- a/apple/Sources/Connlib/Models/InterfaceAddresses.swift
+++ b/apple/Sources/Connlib/Models/InterfaceAddresses.swift
@@ -1,0 +1,11 @@
+//
+//  InterfaceAddresses.swift
+//  (c) 2023 Firezone, Inc.
+//  LICENSE: Apache-2.0
+
+import Foundation
+
+public struct InterfaceAddresses {
+    let ipv4: String
+    let ipv6: String
+}

--- a/apple/Sources/Connlib/Models/Resource.swift
+++ b/apple/Sources/Connlib/Models/Resource.swift
@@ -1,0 +1,67 @@
+//
+//  Resource.swift
+//  (c) 2023 Firezone, Inc.
+//  LICENSE: Apache-2.0
+
+import Foundation
+
+public struct Resource: Decodable {
+    enum ResourceLocation {
+        case dns(domain: String, ipv4: String, ipv6: String)
+        case cidr(cidrAddress: String)
+    }
+
+    let name: String
+    let resourceLocation: ResourceLocation
+}
+
+// A DNS resource example:
+//  {
+//    "type": "dns",
+//    "address": "app.posthog.com",
+//    "name": "PostHog",
+//    "ipv4": "100.64.0.1",
+//    "ipv6": "fd00:2021:11111::1"
+//  }
+//
+// A CIDR resource example:
+//   {
+//     "type": "cidr",
+//     "address": "10.0.0.0/24",
+//     "name": "AWS SJC VPC1",
+//   }
+
+extension Resource {
+    enum ResourceKeys: String, CodingKey {
+        case type
+        case address
+        case name
+        case ipv4
+        case ipv6
+    }
+
+    enum DecodeError: Error {
+        case invalidType(String)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ResourceKeys.self)
+        let name = try container.decode(String.self, forKey: .name)
+        let type = try container.decode(String.self, forKey: .type)
+        let resourceLocation: ResourceLocation = try {
+            switch type {
+            case "dns":
+                let domain = try container.decode(String.self, forKey: .address)
+                let ipv4 = try container.decode(String.self, forKey: .ipv4)
+                let ipv6 = try container.decode(String.self, forKey: .ipv6)
+                return .dns(domain: domain, ipv4: ipv4, ipv6: ipv6)
+            case "cidr":
+                let address = try container.decode(String.self, forKey: .address)
+                return .cidr(cidrAddress: address)
+            default:
+                throw DecodeError.invalidType(type)
+            }
+        }()
+        self.init(name: name, resourceLocation: resourceLocation)
+    }
+}

--- a/apple/build-xcframework.sh
+++ b/apple/build-xcframework.sh
@@ -13,6 +13,7 @@ for sdk in macosx iphoneos iphonesimulator; do
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 done
 
+rm -rf ./Connlib.xcframework
 xcodebuild -create-xcframework \
   -framework ./connlib-iphoneos.xcarchive/Products/Library/Frameworks/connlib.framework \
   -framework ./connlib-iphonesimulator.xcarchive/Products/Library/Frameworks/connlib.framework \

--- a/apple/connlib.xcodeproj/project.pbxproj
+++ b/apple/connlib.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		6FDEBD6C2A382AFE00FD926A /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEBD6B2A382AFE00FD926A /* Resource.swift */; };
+		6FDEBD712A3837E100FD926A /* InterfaceAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEBD702A3837E100FD926A /* InterfaceAddresses.swift */; };
 		8D46EDDF29DBC29800FF01CA /* Adapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46EDD729DBC29800FF01CA /* Adapter.swift */; };
 		8D46EDE029DBC29800FF01CA /* CallbackHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46EDD829DBC29800FF01CA /* CallbackHandler.swift */; };
 		8D967B2B29DBA064000B9D58 /* libconnlib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D967B2A29DBA03F000B9D58 /* libconnlib.a */; };
@@ -22,6 +23,7 @@
 
 /* Begin PBXFileReference section */
 		6FDEBD6B2A382AFE00FD926A /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
+		6FDEBD702A3837E100FD926A /* InterfaceAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceAddresses.swift; sourceTree = "<group>"; };
 		8D209DCE29DBE96B00B68D27 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.4.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		8D46EDD629DBC29800FF01CA /* BridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		8D46EDD729DBC29800FF01CA /* Adapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adapter.swift; sourceTree = "<group>"; };
@@ -53,6 +55,7 @@
 			isa = PBXGroup;
 			children = (
 				6FDEBD6B2A382AFE00FD926A /* Resource.swift */,
+				6FDEBD702A3837E100FD926A /* InterfaceAddresses.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -242,6 +245,7 @@
 				8D46EDDF29DBC29800FF01CA /* Adapter.swift in Sources */,
 				8D46EDE029DBC29800FF01CA /* CallbackHandler.swift in Sources */,
 				6FDEBD6C2A382AFE00FD926A /* Resource.swift in Sources */,
+				6FDEBD712A3837E100FD926A /* InterfaceAddresses.swift in Sources */,
 				8DA207FC29DBD80C00703A4A /* SwiftBridgeCore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apple/connlib.xcodeproj/project.pbxproj
+++ b/apple/connlib.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		6FDEBD6C2A382AFE00FD926A /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEBD6B2A382AFE00FD926A /* Resource.swift */; };
 		6FDEBD712A3837E100FD926A /* InterfaceAddresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEBD702A3837E100FD926A /* InterfaceAddresses.swift */; };
+		6FDEBD732A3841FE00FD926A /* IPAddressRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEBD722A3841FE00FD926A /* IPAddressRange.swift */; };
 		8D46EDDF29DBC29800FF01CA /* Adapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46EDD729DBC29800FF01CA /* Adapter.swift */; };
 		8D46EDE029DBC29800FF01CA /* CallbackHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46EDD829DBC29800FF01CA /* CallbackHandler.swift */; };
 		8D967B2B29DBA064000B9D58 /* libconnlib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D967B2A29DBA03F000B9D58 /* libconnlib.a */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		6FDEBD6B2A382AFE00FD926A /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		6FDEBD702A3837E100FD926A /* InterfaceAddresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceAddresses.swift; sourceTree = "<group>"; };
+		6FDEBD722A3841FE00FD926A /* IPAddressRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPAddressRange.swift; sourceTree = "<group>"; };
 		8D209DCE29DBE96B00B68D27 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.4.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		8D46EDD629DBC29800FF01CA /* BridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		8D46EDD729DBC29800FF01CA /* Adapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adapter.swift; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 			children = (
 				6FDEBD6B2A382AFE00FD926A /* Resource.swift */,
 				6FDEBD702A3837E100FD926A /* InterfaceAddresses.swift */,
+				6FDEBD722A3841FE00FD926A /* IPAddressRange.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -246,6 +249,7 @@
 				8D46EDE029DBC29800FF01CA /* CallbackHandler.swift in Sources */,
 				6FDEBD6C2A382AFE00FD926A /* Resource.swift in Sources */,
 				6FDEBD712A3837E100FD926A /* InterfaceAddresses.swift in Sources */,
+				6FDEBD732A3841FE00FD926A /* IPAddressRange.swift in Sources */,
 				8DA207FC29DBD80C00703A4A /* SwiftBridgeCore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/apple/connlib.xcodeproj/project.pbxproj
+++ b/apple/connlib.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6FDEBD6C2A382AFE00FD926A /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDEBD6B2A382AFE00FD926A /* Resource.swift */; };
 		8D46EDDF29DBC29800FF01CA /* Adapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46EDD729DBC29800FF01CA /* Adapter.swift */; };
 		8D46EDE029DBC29800FF01CA /* CallbackHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D46EDD829DBC29800FF01CA /* CallbackHandler.swift */; };
 		8D967B2B29DBA064000B9D58 /* libconnlib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D967B2A29DBA03F000B9D58 /* libconnlib.a */; };
@@ -20,6 +21,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		6FDEBD6B2A382AFE00FD926A /* Resource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		8D209DCE29DBE96B00B68D27 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.4.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		8D46EDD629DBC29800FF01CA /* BridgingHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		8D46EDD729DBC29800FF01CA /* Adapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Adapter.swift; sourceTree = "<group>"; };
@@ -47,6 +49,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6FDEBD6D2A38355D00FD926A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				6FDEBD6B2A382AFE00FD926A /* Resource.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		8D46EDCE29DBC29800FF01CA /* Connlib */ = {
 			isa = PBXGroup;
 			children = (
@@ -55,6 +65,7 @@
 				8D46EDD629DBC29800FF01CA /* BridgingHeader.h */,
 				8D46EDD729DBC29800FF01CA /* Adapter.swift */,
 				8D46EDD829DBC29800FF01CA /* CallbackHandler.swift */,
+				6FDEBD6D2A38355D00FD926A /* Models */,
 			);
 			path = Connlib;
 			sourceTree = "<group>";
@@ -230,6 +241,7 @@
 				8DA207F829DBD80C00703A4A /* connlib-apple.swift in Sources */,
 				8D46EDDF29DBC29800FF01CA /* Adapter.swift in Sources */,
 				8D46EDE029DBC29800FF01CA /* CallbackHandler.swift in Sources */,
+				6FDEBD6C2A382AFE00FD926A /* Resource.swift in Sources */,
 				8DA207FC29DBD80C00703A4A /* SwiftBridgeCore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
- The API to be used by Apple clients takes in portal URL and JWT token
- The tunnel settings are set based on the callbacks received through connlib ffi

It's WIP because I'm investigating these issues:

In macOS:
When I run it in macOS, the tunnel process exits after a while. It seems to be because connlib cannot create a utun device in macOS.

In iOS:
dyld fails to load connlib.
